### PR TITLE
version emoji-mart

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "cssnano": "^4.1.11",
     "detect-passive-events": "^2.0.3",
     "dotenv": "^16.0.3",
-    "emoji-mart": "npm:emoji-mart-lazyload",
+    "emoji-mart": "npm:emoji-mart-lazyload@latest",
     "es6-symbol": "^3.1.3",
     "escape-html": "^1.0.3",
     "exif-js": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4454,9 +4454,9 @@ emittery@^0.13.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
-"emoji-mart@npm:emoji-mart-lazyload":
+"emoji-mart@npm:emoji-mart-lazyload@latest":
   version "3.0.1-j"
-  resolved "https://registry.npmjs.org/emoji-mart-lazyload/-/emoji-mart-lazyload-3.0.1-j.tgz#87a90d30b79d9145ece078d53e3e683c1a10ce9c"
+  resolved "https://registry.yarnpkg.com/emoji-mart-lazyload/-/emoji-mart-lazyload-3.0.1-j.tgz#87a90d30b79d9145ece078d53e3e683c1a10ce9c"
   integrity sha512-0wKF7MR0/iAeCIoiBLY+JjXCugycTgYRC2SL0y9/bjNSQlbeMdzILmPQJAufU/mgLFDUitOvjxLDhOZ9yxZ48g==
   dependencies:
     "@babel/runtime" "^7.0.0"


### PR DESCRIPTION
I had trouble installing Mastodon on Ubuntu 22.04 using the `yarn` version recommended in the official Mastodon installation guide. The `yarn` resolution step would fail while calculating the `emoji-mart-lazyload` dependencies. I think it may be related to this bug in `yarn`:

https://github.com/yarnpkg/berry/issues/1816

Adding `@latest` to the `package.json` entry allows `yarn` to operate as expected.